### PR TITLE
AUV Databags

### DIFF
--- a/workspace/AUV_VIEWER_TRACKS/context/Source_0.1.item
+++ b/workspace/AUV_VIEWER_TRACKS/context/Source_0.1.item
@@ -2,9 +2,9 @@
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:talendfile="platform:/resource/org.talend.model/model/TalendFile.xsd">
   <talendfile:ContextType confirmationNeeded="false" name="Default">
     <contextParameter comment="" name="sourceDir" prompt="sourceDir?" promptNeeded="false" type="id_String" value="/mnt/imos-t4/IMOS/public/AUV/auv_viewer_data"/>
-    <contextParameter comment="" name="include_data" prompt="include_data?" promptNeeded="false" type="id_String" value="&quot;.*TABLE_DATA.*\.csv$&quot;"/>
+    <contextParameter comment="" name="include_data" prompt="include_data?" promptNeeded="false" type="id_String" value="&quot;.*[A-Z]*/TABLE_DATA.*\.csv$&quot;"/>
     <contextParameter comment="" name="exclude" prompt="exclude?" promptNeeded="false" type="id_String" value="/mnt/imos-t4/IMOS/public/AUV/auv_viewer_data/thumbnails"/>
-    <contextParameter comment="" name="include_metadata" prompt="include_metadata?" promptNeeded="false" type="id_String" value="&quot;.*TABLE_METADATA.*\.csv$&quot;"/>
+    <contextParameter comment="" name="include_metadata" prompt="include_metadata?" promptNeeded="false" type="id_String" value="&quot;.*[A-Z]*/TABLE_METADATA.*\.csv$&quot;"/>
     <contextParameter comment="" name="include_reporting" prompt="include_reporting?" promptNeeded="false" type="id_String" value="&quot;.*auvReporting\.csv$&quot;"/>
   </talendfile:ContextType>
   <talendfile:ContextType confirmationNeeded="false" name="Deployment">

--- a/workspace/AUV_VIEWER_TRACKS/context/Source_0.1.properties
+++ b/workspace/AUV_VIEWER_TRACKS/context/Source_0.1.properties
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:TalendProperties="http://www.talend.org/properties">
-  <TalendProperties:Property xmi:id="_EMml8ED2EeO4PMQpaPeV8A" id="_EMU5IED2EeO4PMQpaPeV8A" label="Source" creationDate="2013-10-30T11:58:53.903+1100" modificationDate="2014-11-03T17:27:13.606+1100" version="0.1" statusCode="" item="_EMml8kD2EeO4PMQpaPeV8A" displayName="Source">
+  <TalendProperties:Property xmi:id="_EMml8ED2EeO4PMQpaPeV8A" id="_EMU5IED2EeO4PMQpaPeV8A" label="Source" creationDate="2013-10-30T11:58:53.903+1100" modificationDate="2014-11-24T11:28:06.549+1100" version="0.1" statusCode="" item="_EMml8kD2EeO4PMQpaPeV8A" displayName="Source">
     <author href="../talend.project#_tfba8jSLEeS5EceRBigRTQ"/>
   </TalendProperties:Property>
   <TalendProperties:ItemState xmi:id="_7gRfgDSLEeS5EceRBigRTQ" path=""/>

--- a/workspace/AUV_VIEWER_TRACKS/process/AUV_VIEWER_TRACK/AUV_VIEWER_TRACK_harvester_0.1.item
+++ b/workspace/AUV_VIEWER_TRACKS/process/AUV_VIEWER_TRACK/AUV_VIEWER_TRACK_harvester_0.1.item
@@ -11,8 +11,8 @@
     <contextParameter comment="" name="paramFile" prompt="paramFile?" promptNeeded="false" repositoryContextId="_1TC3MFL9EeOUYeJDXGjB-Q" type="id_String" value="null"/>
     <contextParameter comment="" name="exclude" prompt="exclude?" promptNeeded="false" repositoryContextId="_EMU5IED2EeO4PMQpaPeV8A" type="id_String" value="/mnt/imos-t4/IMOS/public/AUV/auv_viewer_data/thumbnails"/>
     <contextParameter comment="" name="include_reporting" prompt="include_reporting?" promptNeeded="false" repositoryContextId="_EMU5IED2EeO4PMQpaPeV8A" type="id_String" value="&quot;.*auvReporting\.csv$&quot;"/>
-    <contextParameter comment="" name="include_data" prompt="include_data?" promptNeeded="false" repositoryContextId="_EMU5IED2EeO4PMQpaPeV8A" type="id_String" value="&quot;.*TABLE_DATA.*\.csv$&quot;"/>
-    <contextParameter comment="" name="include_metadata" prompt="include_metadata?" promptNeeded="false" repositoryContextId="_EMU5IED2EeO4PMQpaPeV8A" type="id_String" value="&quot;.*TABLE_METADATA.*\.csv$&quot;"/>
+    <contextParameter comment="" name="include_data" prompt="include_data?" promptNeeded="false" repositoryContextId="_EMU5IED2EeO4PMQpaPeV8A" type="id_String" value="&quot;.*[A-Z]*/TABLE_DATA.*\.csv$&quot;"/>
+    <contextParameter comment="" name="include_metadata" prompt="include_metadata?" promptNeeded="false" repositoryContextId="_EMU5IED2EeO4PMQpaPeV8A" type="id_String" value="&quot;.*[A-Z]*/TABLE_METADATA.*\.csv$&quot;"/>
     <contextParameter comment="" name="sourceDir" prompt="sourceDir?" promptNeeded="false" repositoryContextId="_EMU5IED2EeO4PMQpaPeV8A" type="id_String" value="/mnt/imos-t4/IMOS/public/AUV/auv_viewer_data"/>
   </context>
   <context confirmationNeeded="false" name="Deployment">

--- a/workspace/AUV_VIEWER_TRACKS/process/AUV_VIEWER_TRACK/AUV_VIEWER_TRACK_harvester_0.1.properties
+++ b/workspace/AUV_VIEWER_TRACKS/process/AUV_VIEWER_TRACK/AUV_VIEWER_TRACK_harvester_0.1.properties
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:TalendProperties="http://www.talend.org/properties">
-  <TalendProperties:Property xmi:id="_D9TKoDSWEeS5EceRBigRTQ" id="_D9PgQDSWEeS5EceRBigRTQ" label="AUV_VIEWER_TRACK_harvester" creationDate="2014-09-05T11:46:24.329+1000" modificationDate="2014-11-21T18:06:28.753+1100" version="0.1" statusCode="" item="_D9TKojSWEeS5EceRBigRTQ" displayName="AUV_VIEWER_TRACK_harvester">
+  <TalendProperties:Property xmi:id="_D9TKoDSWEeS5EceRBigRTQ" id="_D9PgQDSWEeS5EceRBigRTQ" label="AUV_VIEWER_TRACK_harvester" creationDate="2014-09-05T11:46:24.329+1000" modificationDate="2014-11-24T11:25:54.007+1100" version="0.1" statusCode="" item="_D9TKojSWEeS5EceRBigRTQ" displayName="AUV_VIEWER_TRACK_harvester">
     <author href="../../talend.project#_tfba8jSLEeS5EceRBigRTQ"/>
   </TalendProperties:Property>
   <TalendProperties:ItemState xmi:id="_D9TKoTSWEeS5EceRBigRTQ" path="AUV_VIEWER_TRACK"/>


### PR DESCRIPTION
- the exclude seems to still recursive list directories. Instead of
  using the exclude 'capability' , wildcards were added to the
  'include' s to only harvest folders starting with uppercase (ie
  campaigns) and not harvesting the folder called 'thumbnails' at the
  same time
