### PR TITLE
aodn_csiro_cmar: parameters conform naming convention

### DIFF
--- a/workspace/AODN_CSIRO_CMAR/context/MetadataADCP_0.1.item
+++ b/workspace/AODN_CSIRO_CMAR/context/MetadataADCP_0.1.item
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <talendfile:ContextType xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:talendfile="platform:/resource/org.talend.model/model/TalendFile.xsd" confirmationNeeded="false" name="Default">
-  <contextParameter comment="" name="Metadata_URL_ADCP" prompt="Metadata_URL_ADCP?" promptNeeded="false" type="id_String" value="http://localhost:8080/geonetwork"/>
-  <contextParameter comment="" name="Metadata_Username_ADCP" prompt="Metadata_Username_ADCP?" promptNeeded="false" type="id_String" value="admin"/>
-  <contextParameter comment="" name="Metadata_Password_ADCP" prompt="Metadata_Password_ADCP?" promptNeeded="false" type="id_String" value="admin"/>
+  <contextParameter comment="" name="Metadata_URL" prompt="Metadata_URL?" promptNeeded="false" type="id_String" value="http://localhost:8080/geonetwork"/>
+  <contextParameter comment="" name="Metadata_Username" prompt="Metadata_Username?" promptNeeded="false" type="id_String" value="admin"/>
+  <contextParameter comment="" name="Metadata_Password" prompt="Metadata_Password?" promptNeeded="false" type="id_String" value="admin"/>
   <contextParameter comment="" name="Metadata_UUID_ADCP" prompt="Metadata_UUID_ADCP?" promptNeeded="false" type="id_String" value="b376db1f-04ad-4dff-ad44-9f8e423665c4"/>
   <contextParameter comment="" name="Metadata_SpatialTable_ADCP" prompt="Metadata_SpatialTable_ADCP?" promptNeeded="false" type="id_String" value="aodn_csiro_cmar_adcp_map"/>
   <contextParameter comment="" name="Metadata_SpatialColumn_ADCP" prompt="Metadata_SpatialColumn_ADCP?" promptNeeded="false" type="id_String" value="geom"/>

--- a/workspace/AODN_CSIRO_CMAR/process/aodn_csiro_cmar_harvester_0.1.item
+++ b/workspace/AODN_CSIRO_CMAR/process/aodn_csiro_cmar_harvester_0.1.item
@@ -9,12 +9,12 @@
     <contextParameter comment="" name="Destination_Server" prompt="Destination_Server?" promptNeeded="false" repositoryContextId="_2QHFYHmqEeOnMNAUOu1ENQ" type="id_String" value="po.aodn.org.au"/>
     <contextParameter comment="" name="logDir" prompt="logDir?" promptNeeded="false" repositoryContextId="_uuyScHyeEeOBc4eP00PLRQ" type="id_String" value="/tmp/aodn_csiro_cmar"/>
     <contextParameter comment="" name="paramFile" prompt="paramFile?" promptNeeded="false" repositoryContextId="_uuyScHyeEeOBc4eP00PLRQ" type="id_String" value="null"/>
-    <contextParameter comment="" name="Metadata_Password_ADCP" prompt="Metadata_Password_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="admin"/>
+    <contextParameter comment="" name="Metadata_Password" prompt="Metadata_Password?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="admin"/>
     <contextParameter comment="" name="Metadata_SpatialColumn_ADCP" prompt="Metadata_SpatialColumn_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="geom"/>
     <contextParameter comment="" name="Metadata_SpatialResolution_ADCP" prompt="Metadata_SpatialResolution_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="2"/>
     <contextParameter comment="" name="Metadata_SpatialTable_ADCP" prompt="Metadata_SpatialTable_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="aodn_csiro_cmar_adcp_map"/>
-    <contextParameter comment="" name="Metadata_URL_ADCP" prompt="Metadata_URL_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="http://localhost:8080/geonetwork"/>
-    <contextParameter comment="" name="Metadata_Username_ADCP" prompt="Metadata_Username_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="admin"/>
+    <contextParameter comment="" name="Metadata_URL" prompt="Metadata_URL?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="http://localhost:8080/geonetwork"/>
+    <contextParameter comment="" name="Metadata_Username" prompt="Metadata_Username?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="admin"/>
     <contextParameter comment="" name="Metadata_UUID_ADCP" prompt="Metadata_UUID_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="b376db1f-04ad-4dff-ad44-9f8e423665c4"/>
     <contextParameter comment="" name="Metadata_SpatialColumn_CTD" prompt="Metadata_SpatialColumn_CTD?" promptNeeded="false" repositoryContextId="_eu-DkFMlEeSUx7J3JCM2fA" type="id_String" value="geom"/>
     <contextParameter comment="" name="Metadata_SpatialResolution_CTD" prompt="Metadata_SpatialResolution_CTD?" promptNeeded="false" repositoryContextId="_eu-DkFMlEeSUx7J3JCM2fA" type="id_String" value="2"/>

--- a/workspace/AODN_CSIRO_CMAR/process/aodn_csiro_cmar_subjobs/UpdateMetadata_0.1.item
+++ b/workspace/AODN_CSIRO_CMAR/process/aodn_csiro_cmar_subjobs/UpdateMetadata_0.1.item
@@ -7,12 +7,12 @@
     <contextParameter comment="" name="Destination_Port" prompt="Destination_Port?" promptNeeded="false" repositoryContextId="_2QHFYHmqEeOnMNAUOu1ENQ" type="id_String" value="5432"/>
     <contextParameter comment="" name="Destination_Schema" prompt="Destination_Schema?" promptNeeded="false" repositoryContextId="_2QHFYHmqEeOnMNAUOu1ENQ" type="id_String" value="aodn_csiro_cmar"/>
     <contextParameter comment="" name="Destination_Server" prompt="Destination_Server?" promptNeeded="false" repositoryContextId="_2QHFYHmqEeOnMNAUOu1ENQ" type="id_String" value="po.aodn.org.au"/>
-    <contextParameter comment="" name="Metadata_Password_ADCP" prompt="Metadata_Password_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="admin"/>
+    <contextParameter comment="" name="Metadata_Password" prompt="Metadata_Password?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="admin"/>
     <contextParameter comment="" name="Metadata_SpatialColumn_ADCP" prompt="Metadata_SpatialColumn_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="geom"/>
     <contextParameter comment="" name="Metadata_SpatialResolution_ADCP" prompt="Metadata_SpatialResolution_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="2"/>
     <contextParameter comment="" name="Metadata_SpatialTable_ADCP" prompt="Metadata_SpatialTable_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="aodn_csiro_cmar_adcp_map"/>
-    <contextParameter comment="" name="Metadata_URL_ADCP" prompt="Metadata_URL_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="http://localhost:8080/geonetwork"/>
-    <contextParameter comment="" name="Metadata_Username_ADCP" prompt="Metadata_Username_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="admin"/>
+    <contextParameter comment="" name="Metadata_URL" prompt="Metadata_URL?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="http://localhost:8080/geonetwork"/>
+    <contextParameter comment="" name="Metadata_Username" prompt="Metadata_Username?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="admin"/>
     <contextParameter comment="" name="Metadata_UUID_ADCP" prompt="Metadata_UUID_ADCP?" promptNeeded="false" repositoryContextId="_oFoF8AV-EeSJgc0tceHsgg" type="id_String" value="b376db1f-04ad-4dff-ad44-9f8e423665c4"/>
     <contextParameter comment="" name="Metadata_SpatialColumn_CTD" prompt="Metadata_SpatialColumn_CTD?" promptNeeded="false" repositoryContextId="_eu-DkFMlEeSUx7J3JCM2fA" type="id_String" value="geom"/>
     <contextParameter comment="" name="Metadata_SpatialResolution_CTD" prompt="Metadata_SpatialResolution_CTD?" promptNeeded="false" repositoryContextId="_eu-DkFMlEeSUx7J3JCM2fA" type="id_String" value="2"/>
@@ -88,9 +88,9 @@
     <elementParameter field="DBTABLE" name="TABLE" value="context.Metadata_SpatialTable_ADCP"/>
     <elementParameter field="TEXT" name="COLUMN" value="context.Metadata_SpatialColumn_ADCP"/>
     <elementParameter field="TEXT" name="RESOLUTION" value="context.Metadata_SpatialResolution_ADCP"/>
-    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL_ADCP"/>
-    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username_ADCP"/>
-    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password_ADCP"/>
+    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL"/>
+    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username"/>
+    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password"/>
     <elementParameter field="TEXT" name="UUID" value="context.Metadata_UUID_ADCP"/>
     <elementParameter field="TEXT" name="CONNECTION_FORMAT" value="row"/>
     <elementParameter field="CHECK" name="INFORMATION" value="false"/>
@@ -111,9 +111,9 @@
     <elementParameter field="DBTABLE" name="TABLE" value="context.Metadata_SpatialTable_CTD"/>
     <elementParameter field="TEXT" name="COLUMN" value="context.Metadata_SpatialColumn_CTD"/>
     <elementParameter field="TEXT" name="RESOLUTION" value="context.Metadata_SpatialResolution_CTD"/>
-    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL_ADCP"/>
-    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username_ADCP"/>
-    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password_ADCP"/>
+    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL"/>
+    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username"/>
+    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password"/>
     <elementParameter field="TEXT" name="UUID" value="context.Metadata_UUID_CTD"/>
     <elementParameter field="TEXT" name="CONNECTION_FORMAT" value="row"/>
     <elementParameter field="CHECK" name="INFORMATION" value="false"/>
@@ -134,9 +134,9 @@
     <elementParameter field="DBTABLE" name="TABLE" value="context.Metadata_SpatialTable_Hydrology"/>
     <elementParameter field="TEXT" name="COLUMN" value="context.Metadata_SpatialColumn_Hydrology"/>
     <elementParameter field="TEXT" name="RESOLUTION" value="context.Metadata_SpatialResolution_Hydrology"/>
-    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL_ADCP"/>
-    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username_ADCP"/>
-    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password_ADCP"/>
+    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL"/>
+    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username"/>
+    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password"/>
     <elementParameter field="TEXT" name="UUID" value="context.Metadata_UUID_Hydrology"/>
     <elementParameter field="TEXT" name="CONNECTION_FORMAT" value="row"/>
     <elementParameter field="CHECK" name="INFORMATION" value="false"/>
@@ -157,9 +157,9 @@
     <elementParameter field="DBTABLE" name="TABLE" value="context.Metadata_SpatialTable_Mooring"/>
     <elementParameter field="TEXT" name="COLUMN" value="context.Metadata_SpatialColumn_Mooring"/>
     <elementParameter field="TEXT" name="RESOLUTION" value="context.Metadata_SpatialResolution_Mooring"/>
-    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL_ADCP"/>
-    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username_ADCP"/>
-    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password_ADCP"/>
+    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL"/>
+    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username"/>
+    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password"/>
     <elementParameter field="TEXT" name="UUID" value="context.Metadata_UUID_Mooring"/>
     <elementParameter field="TEXT" name="CONNECTION_FORMAT" value="row"/>
     <elementParameter field="CHECK" name="INFORMATION" value="false"/>
@@ -180,9 +180,9 @@
     <elementParameter field="DBTABLE" name="TABLE" value="context.Metadata_SpatialTable_Trajectory"/>
     <elementParameter field="TEXT" name="COLUMN" value="context.Metadata_SpatialColumn_Trajectory"/>
     <elementParameter field="TEXT" name="RESOLUTION" value="context.Metadata_SpatialResolution_Trajectory"/>
-    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL_ADCP"/>
-    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username_ADCP"/>
-    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password_ADCP"/>
+    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL"/>
+    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username"/>
+    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password"/>
     <elementParameter field="TEXT" name="UUID" value="context.Metadata_UUID_Trajectory"/>
     <elementParameter field="TEXT" name="CONNECTION_FORMAT" value="row"/>
     <elementParameter field="CHECK" name="INFORMATION" value="false"/>
@@ -203,9 +203,9 @@
     <elementParameter field="DBTABLE" name="TABLE" value="context.Metadata_SpatialTable_Underway"/>
     <elementParameter field="TEXT" name="COLUMN" value="context.Metadata_SpatialColumn_Underway"/>
     <elementParameter field="TEXT" name="RESOLUTION" value="context.Metadata_SpatialResolution_Underway"/>
-    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL_ADCP"/>
-    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username_ADCP"/>
-    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password_ADCP"/>
+    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL"/>
+    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username"/>
+    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password"/>
     <elementParameter field="TEXT" name="UUID" value="context.Metadata_UUID_Underway"/>
     <elementParameter field="TEXT" name="CONNECTION_FORMAT" value="row"/>
     <elementParameter field="CHECK" name="INFORMATION" value="false"/>
@@ -226,9 +226,9 @@
     <elementParameter field="DBTABLE" name="TABLE" value="context.Metadata_SpatialTable_XBT"/>
     <elementParameter field="TEXT" name="COLUMN" value="context.Metadata_SpatialColumn_XBT"/>
     <elementParameter field="TEXT" name="RESOLUTION" value="context.Metadata_SpatialResolution_XBT"/>
-    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL_ADCP"/>
-    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username_ADCP"/>
-    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password_ADCP"/>
+    <elementParameter field="TEXT" name="GN_SERVICE_URL" value="context.Metadata_URL"/>
+    <elementParameter field="TEXT" name="GN_USERNAME" value="context.Metadata_Username"/>
+    <elementParameter field="TEXT" name="GN_PASSWORD" value="context.Metadata_Password"/>
     <elementParameter field="TEXT" name="UUID" value="context.Metadata_UUID_XBT"/>
     <elementParameter field="TEXT" name="CONNECTION_FORMAT" value="row"/>
     <elementParameter field="CHECK" name="INFORMATION" value="false"/>


### PR DESCRIPTION
rename parameters to conform to standard:
 * Metadata_Username_ADCP -> Metadata_Username
 * Metadata_Password_ADCP -> Metadata_Password
 * Metadata_URL_ADCP -> Metadata_URL

@xhoenner @anguss00 That'll conform to the current standard.