### PR TITLE
Abort by default if no files present in source directory to prevent all ...

### DIFF
--- a/workspace/AATAMS_BIOLOGGING_PENGUIN/process/aatams_penguin_harvester_0.1.item
+++ b/workspace/AATAMS_BIOLOGGING_PENGUIN/process/aatams_penguin_harvester_0.1.item
@@ -70,7 +70,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/AATAMS_BIOLOGGING_SHEARWATER/process/aatams_shearwater_harvester_0.1.item
+++ b/workspace/AATAMS_BIOLOGGING_SHEARWATER/process/aatams_shearwater_harvester_0.1.item
@@ -71,7 +71,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="false"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/AATAMS_SATTAG_DM/process/aatams_sattag_dm_harvester_0.1.item
+++ b/workspace/AATAMS_SATTAG_DM/process/aatams_sattag_dm_harvester_0.1.item
@@ -98,7 +98,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.unarchived_folder"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>
@@ -349,7 +349,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.unarchived_folder"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/AATAMS_SATTAG_DM/process/aatams_sattag_dm_subjobs/Unzip_AllFiles_0.1.item
+++ b/workspace/AATAMS_SATTAG_DM/process/aatams_sattag_dm_subjobs/Unzip_AllFiles_0.1.item
@@ -65,7 +65,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.archived_folder"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES"/>
     <elementParameter field="CHECK" name="IFEXCLUDE" value="false"/>

--- a/workspace/AATAMS_SATTAG_NRT/process/aatams_sattag_nrt_harvester_0.1.item
+++ b/workspace/AATAMS_SATTAG_NRT/process/aatams_sattag_nrt_harvester_0.1.item
@@ -147,7 +147,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.archived_folder"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ABOS_CURRENTS/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/ABOS_CURRENTS/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -192,7 +192,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ABOS_SOFS_SURFACE_FLUXES/process/ABOS_SOFS_surfaceflux_harvester_1.0.item
+++ b/workspace/ABOS_SOFS_SURFACE_FLUXES/process/ABOS_SOFS_surfaceflux_harvester_1.0.item
@@ -240,7 +240,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ABOS_SOFS_SURFACE_PROPERTIES/process/ABOS_SOFS_surfaceprop_harvester_1.0.item
+++ b/workspace/ABOS_SOFS_SURFACE_PROPERTIES/process/ABOS_SOFS_surfaceprop_harvester_1.0.item
@@ -181,7 +181,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ABOS_SOTS/process/ABOS_SOTS_harvester_0.1.item
+++ b/workspace/ABOS_SOTS/process/ABOS_SOTS_harvester_0.1.item
@@ -91,7 +91,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/process/ABOS_TS_SINGLE_INST_timeseries_harvester_0.1.item
+++ b/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/process/ABOS_TS_SINGLE_INST_timeseries_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/process/ABOS_TS_SINGLE_INST_timeseries_harvester_1.0.item
+++ b/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/process/ABOS_TS_SINGLE_INST_timeseries_harvester_1.0.item
@@ -232,7 +232,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ACORN_HOURLY_AVG_NONQC/process/ACORN_hourly_averaged_nonQC_harvester_0.1.item
+++ b/workspace/ACORN_HOURLY_AVG_NONQC/process/ACORN_hourly_averaged_nonQC_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ACORN_HOURLY_AVG_NONQC/process/ACORN_hourly_averaged_nonQC_harvester_1.0.item
+++ b/workspace/ACORN_HOURLY_AVG_NONQC/process/ACORN_hourly_averaged_nonQC_harvester_1.0.item
@@ -193,7 +193,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ACORN_HOURLY_AVG_QC/process/ACORN_HOURLY_AVG_QC_harvester_0.1.item
+++ b/workspace/ACORN_HOURLY_AVG_QC/process/ACORN_HOURLY_AVG_QC_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ACORN_HOURLY_AVG_QC/process/ACORN_HOURLY_AVG_QC_harvester_1.0.item
+++ b/workspace/ACORN_HOURLY_AVG_QC/process/ACORN_HOURLY_AVG_QC_harvester_1.0.item
@@ -193,7 +193,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ACORN_RADIAL_NONQC/process/ACORN_radial_nonQC_harvester_0.1.item
+++ b/workspace/ACORN_RADIAL_NONQC/process/ACORN_radial_nonQC_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ACORN_RADIAL_NONQC/process/ACORN_radial_nonQC_harvester_1.0.item
+++ b/workspace/ACORN_RADIAL_NONQC/process/ACORN_radial_nonQC_harvester_1.0.item
@@ -193,7 +193,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ACORN_RADIAL_QC/process/ACORN_radial_QC_harvester_0.1.item
+++ b/workspace/ACORN_RADIAL_QC/process/ACORN_radial_QC_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ACORN_RADIAL_QC/process/ACORN_radial_QC_harvester_1.0.item
+++ b/workspace/ACORN_RADIAL_QC/process/ACORN_radial_QC_harvester_1.0.item
@@ -193,7 +193,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANFOG_DM/ANFOG_DM-master/process/ANFOG_RT/HarvestMetadataFileSystem_RT/HarvestMetadataFileSystem_RT_0.1.item
+++ b/workspace/ANFOG_DM/ANFOG_DM-master/process/ANFOG_RT/HarvestMetadataFileSystem_RT/HarvestMetadataFileSystem_RT_0.1.item
@@ -183,7 +183,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANFOG_DM/ANFOG_DM-master/process/ANFOG_dm/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
+++ b/workspace/ANFOG_DM/ANFOG_DM-master/process/ANFOG_dm/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
@@ -184,7 +184,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANFOG_DM/process/ANFOG_dm/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
+++ b/workspace/ANFOG_DM/process/ANFOG_dm/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
@@ -184,7 +184,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANFOG_RT/ANFOG_RT/HarvestMetadataFileSystem_RT/items/anfog_dm/process/ANFOG_RT/HarvestMetadataFileSystem_RT/HarvestMetadataFileSystem_RT_0.1.item
+++ b/workspace/ANFOG_RT/ANFOG_RT/HarvestMetadataFileSystem_RT/items/anfog_dm/process/ANFOG_RT/HarvestMetadataFileSystem_RT/HarvestMetadataFileSystem_RT_0.1.item
@@ -183,7 +183,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANFOG_RT/ANFOG_RT/mainANFOG_RT/items/anfog_dm/process/ANFOG_RT/HarvestMetadataFileSystem_RT/HarvestMetadataFileSystem_RT_0.1.item
+++ b/workspace/ANFOG_RT/ANFOG_RT/mainANFOG_RT/items/anfog_dm/process/ANFOG_RT/HarvestMetadataFileSystem_RT/HarvestMetadataFileSystem_RT_0.1.item
@@ -183,7 +183,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANFOG_RT/process/ANFOG_RT/HarvestMetadataFileSystem_RT/HarvestMetadataFileSystem_RT_0.1.item
+++ b/workspace/ANFOG_RT/process/ANFOG_RT/HarvestMetadataFileSystem_RT/HarvestMetadataFileSystem_RT_0.1.item
@@ -199,7 +199,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_ACIDIFICATION_DM/process/ANMN_acidification_dm_harvester_1.0.item
+++ b/workspace/ANMN_ACIDIFICATION_DM/process/ANMN_acidification_dm_harvester_1.0.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_ACIDIFICATION_NRT/process/ANMN_acidification_nrt_harvester_1.0.item
+++ b/workspace/ANMN_ACIDIFICATION_NRT/process/ANMN_acidification_nrt_harvester_1.0.item
@@ -187,7 +187,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_ADCP_TIMESERIES/process/ANMN_velocity_timeseries_harvester_0.1.item
+++ b/workspace/ANMN_ADCP_TIMESERIES/process/ANMN_velocity_timeseries_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_ADCP_TIMESERIES/process/ANMN_velocity_timeseries_harvester_1.0.item
+++ b/workspace/ANMN_ADCP_TIMESERIES/process/ANMN_velocity_timeseries_harvester_1.0.item
@@ -187,7 +187,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_BURST_AVG_TIMESERIES/process/ANMN_BURST_AVG_TIMESERIES_harvester_0.1.item
+++ b/workspace/ANMN_BURST_AVG_TIMESERIES/process/ANMN_BURST_AVG_TIMESERIES_harvester_0.1.item
@@ -109,7 +109,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_NRS_CTD_PROFILES/process/subjobs/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
+++ b/workspace/ANMN_NRS_CTD_PROFILES/process/subjobs/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
@@ -186,7 +186,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_NRS_DAR_YON_TS/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/ANMN_NRS_DAR_YON_TS/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/process/ANMN_NRS_RT_Biogeochem_timeseries_harvester_0.1.item
+++ b/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/process/ANMN_NRS_RT_Biogeochem_timeseries_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/process/ANMN_NRS_RT_Biogeochem_timeseries_harvester_1.0.item
+++ b/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/process/ANMN_NRS_RT_Biogeochem_timeseries_harvester_1.0.item
@@ -252,7 +252,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_NRS_RT_METEO_TIMESERIES/process/ANMN_NRS_RT_Meteo_timeseries_harvester_0.1.item
+++ b/workspace/ANMN_NRS_RT_METEO_TIMESERIES/process/ANMN_NRS_RT_Meteo_timeseries_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_NRS_RT_METEO_TIMESERIES/process/ANMN_NRS_RT_Meteo_timeseries_harvester_1.0.item
+++ b/workspace/ANMN_NRS_RT_METEO_TIMESERIES/process/ANMN_NRS_RT_Meteo_timeseries_harvester_1.0.item
@@ -252,7 +252,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/process/ANMN_NRS_RT_Wave_timeseries_harvester_0.1.item
+++ b/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/process/ANMN_NRS_RT_Wave_timeseries_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/process/ANMN_NRS_RT_Wave_timeseries_harvester_1.0.item
+++ b/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/process/ANMN_NRS_RT_Wave_timeseries_harvester_1.0.item
@@ -252,7 +252,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_TS_TIMESERIES/process/ANMN_TS_timeseries_harvester_0.1.item
+++ b/workspace/ANMN_TS_TIMESERIES/process/ANMN_TS_timeseries_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_TS_TIMESERIES/process/ANMN_TS_timeseries_harvester_1.0.item
+++ b/workspace/ANMN_TS_TIMESERIES/process/ANMN_TS_timeseries_harvester_1.0.item
@@ -232,7 +232,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/ANMN_T_REGRIDDED/process/ANMN_t_regridded/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
+++ b/workspace/ANMN_T_REGRIDDED/process/ANMN_t_regridded/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
@@ -184,7 +184,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/AODN_CSIRO_CMAR/process/aodn_csiro_cmar_harvester_0.1.item
+++ b/workspace/AODN_CSIRO_CMAR/process/aodn_csiro_cmar_harvester_0.1.item
@@ -100,7 +100,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/AODN_DSTO/process/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
+++ b/workspace/AODN_DSTO/process/HarvestMetadataFileSystem/HarvestMetadataFileSystem_0.1.item
@@ -184,7 +184,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/AUV/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/AUV/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/AUV_VIEWER_TRACKS/process/AUV_VIEWER_TRACK/AUV_VIEWER_TRACK_harvester_0.1.item
+++ b/workspace/AUV_VIEWER_TRACKS/process/AUV_VIEWER_TRACK/AUV_VIEWER_TRACK_harvester_0.1.item
@@ -83,7 +83,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include_metadata"/>
@@ -189,7 +189,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include_data"/>
@@ -276,7 +276,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include_reporting"/>

--- a/workspace/GSLA_DM00/process/GSLA_DM00_harvester_0.1.item
+++ b/workspace/GSLA_DM00/process/GSLA_DM00_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/GSLA_DM00/process/GSLA_DM00_harvester_1.0.item
+++ b/workspace/GSLA_DM00/process/GSLA_DM00_harvester_1.0.item
@@ -204,7 +204,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/GSLA_NRT00/process/GSLA_NRT00_harvester_0.1.item
+++ b/workspace/GSLA_NRT00/process/GSLA_NRT00_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/GSLA_NRT00/process/GSLA_NRT00_harvester_1.0.item
+++ b/workspace/GSLA_NRT00/process/GSLA_NRT00_harvester_1.0.item
@@ -204,7 +204,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/HAWKSBILL_TURTLES_NT/process/aodn_nt_sattag_hawksbill_harvester_0.1.item
+++ b/workspace/HAWKSBILL_TURTLES_NT/process/aodn_nt_sattag_hawksbill_harvester_0.1.item
@@ -93,7 +93,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/NOAA_DRIFTERS/process/NOAA_drifters_harvester_1.0.item
+++ b/workspace/NOAA_DRIFTERS/process/NOAA_drifters_harvester_1.0.item
@@ -204,7 +204,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_ASF_MFT/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SOOP_ASF_MFT/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_ASF_MT/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SOOP_ASF_MT/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_BA/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SOOP_BA/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -181,7 +181,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_CO2/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SOOP_CO2/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -173,7 +173,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_SST/process/SOOP_SST/SOOP_SST_harvester_2.0.item
+++ b/workspace/SOOP_SST/process/SOOP_SST/SOOP_SST_harvester_2.0.item
@@ -97,7 +97,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="true"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_TMV/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SOOP_TMV/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_TMV_NRT/process/SOOP_TMV_NRT_harvester_0.1.item
+++ b/workspace/SOOP_TMV_NRT/process/SOOP_TMV_NRT_harvester_0.1.item
@@ -86,7 +86,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.folder_10secs_transect"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="false"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_TMV_NRT/process/soop_tmv_nrt_Subjobs/copy_data_to_public_0.1.item
+++ b/workspace/SOOP_TMV_NRT/process/soop_tmv_nrt_Subjobs/copy_data_to_public_0.1.item
@@ -78,7 +78,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.archived_folder"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="false"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES"/>
     <elementParameter field="CHECK" name="IFEXCLUDE" value="true"/>
@@ -194,7 +194,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.archived_folder"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="false"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES"/>
     <elementParameter field="CHECK" name="IFEXCLUDE" value="true"/>
@@ -310,7 +310,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.archived_folder"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="false"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES"/>
     <elementParameter field="CHECK" name="IFEXCLUDE" value="true"/>
@@ -386,7 +386,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.archived_folder"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="false"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES"/>
     <elementParameter field="CHECK" name="IFEXCLUDE" value="true"/>

--- a/workspace/SOOP_TRV/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SOOP_TRV/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_XBT_DM/process/SOOP_XBT_DM_harvester_0.1.item
+++ b/workspace/SOOP_XBT_DM/process/SOOP_XBT_DM_harvester_0.1.item
@@ -92,7 +92,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SOOP_XBT_NRT/process/SOOP_XBT_NRT_harvester_0.1.item
+++ b/workspace/SOOP_XBT_NRT/process/SOOP_XBT_NRT_harvester_0.1.item
@@ -137,7 +137,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SRS_ALTIMETRY/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SRS_ALTIMETRY/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SRS_LJCO_AERONET_TS/process/SRS_LJCO_AERONET_TS/SRS_LJCO_AERONET_TS_harvester_0.1.item
+++ b/workspace/SRS_LJCO_AERONET_TS/process/SRS_LJCO_AERONET_TS/SRS_LJCO_AERONET_TS_harvester_0.1.item
@@ -95,7 +95,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SRS_OC/process/SRS_OC_harvester_0.1.item
+++ b/workspace/SRS_OC/process/SRS_OC_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SRS_OC/process/SRS_OC_harvester_1.0.item
+++ b/workspace/SRS_OC/process/SRS_OC_harvester_1.0.item
@@ -130,7 +130,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SRS_OC_BODBAW/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SRS_OC_BODBAW/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -180,7 +180,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SRS_OC_SOOP_RAD/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SRS_OC_SOOP_RAD/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -181,7 +181,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SRS_SST/process/SRS_SST_harvester_0.1.item
+++ b/workspace/SRS_SST/process/SRS_SST_harvester_0.1.item
@@ -211,7 +211,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>

--- a/workspace/SRS_SST/process/SRS_SST_harvester_1.0.item
+++ b/workspace/SRS_SST/process/SRS_SST_harvester_1.0.item
@@ -130,7 +130,7 @@
     <elementParameter field="DIRECTORY" name="DIRECTORY" value="context.sourceDir"/>
     <elementParameter field="CHECK" name="INCLUDSUBDIR" value="true"/>
     <elementParameter field="CLOSED_LIST" name="CASE_SENSITIVE" value="YES"/>
-    <elementParameter field="CHECK" name="ERROR" value="false"/>
+    <elementParameter field="CHECK" name="ERROR" value="true"/>
     <elementParameter field="CHECK" name="GLOBEXPRESSIONS" value="false"/>
     <elementParameter field="TABLE" name="FILES">
       <elementValue elementRef="FILEMASK" value="context.include"/>


### PR DESCRIPTION
...data being removed from the database

This pull request will change the behaviour of iIndexFiles in all harvesters to abort if there are no files in the source directory.  This is to prevent all data from being removed by harvesters e.g.  by iDeleteResources components due to system errors such as the sshfs filesystem problem that occurred recently for SRS data.

It sets the 'Generate Error if no file found' option on iIndexFiles components in these harvesters.

If you are working on any of these harvesters, please ensure you turn this option on in your version to ensure these changes are not reverted when your changes are merged.

If you think any of these harvesters need to handle empty directories - let me know and I'll remove them from the changes below