### PR TITLE
ANMN_NRS_CTD_PROFILES: fix db connection for delete

### DIFF
--- a/workspace/ANMN_NRS_CTD_PROFILES/process/subjobs/DataHarvest_0.1.item
+++ b/workspace/ANMN_NRS_CTD_PROFILES/process/subjobs/DataHarvest_0.1.item
@@ -100,7 +100,7 @@
     <elementParameter field="TEXT" name="UNIQUE_NAME" value="tPostgresqlRow_1"/>
     <elementParameter field="TECHNICAL" name="PROPERTY:PROPERTY_TYPE" value="REPOSITORY"/>
     <elementParameter field="TECHNICAL" name="PROPERTY:REPOSITORY_PROPERTY_TYPE" value="_T73w8AfEEeS6S4wYAZSNCg"/>
-    <elementParameter field="CHECK" name="USE_EXISTING_CONNECTION" value="true"/>
+    <elementParameter field="CHECK" name="USE_EXISTING_CONNECTION" value="false"/>
     <elementParameter field="COMPONENT_LIST" name="CONNECTION" value="tPostgresqlConnection_1"/>
     <elementParameter field="TEXT" name="HOST" value="context.DestinationDB_Server"/>
     <elementParameter field="TEXT" name="PORT" value="context.DestinationDB_Port"/>

--- a/workspace/ANMN_NRS_CTD_PROFILES/process/subjobs/DataHarvest_0.1.properties
+++ b/workspace/ANMN_NRS_CTD_PROFILES/process/subjobs/DataHarvest_0.1.properties
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:TalendProperties="http://www.talend.org/properties">
-  <TalendProperties:Property xmi:id="_6USuQGarEeOj-aYbiLXYfw" id="_WLMugHmWEeO3Y9k88sZyxQ" label="DataHarvest" creationDate="2013-12-17T11:43:49.028+1100" modificationDate="2015-01-13T16:16:38.824+1100" version="0.1" statusCode="" item="_6USuQmarEeOj-aYbiLXYfw" displayName="DataHarvest">
+  <TalendProperties:Property xmi:id="_6USuQGarEeOj-aYbiLXYfw" id="_WLMugHmWEeO3Y9k88sZyxQ" label="DataHarvest" creationDate="2013-12-17T11:43:49.028+1100" modificationDate="2015-04-29T14:13:17.847+1000" version="0.1" statusCode="" item="_6USuQmarEeOj-aYbiLXYfw" displayName="DataHarvest">
     <author href="../../talend.project#_v6Fc8Cf9EeS-YZ9BEyjySQ"/>
   </TalendProperties:Property>
   <TalendProperties:ItemState xmi:id="_3aMUMCgEEeSvVMH2fah85w" path="subjobs"/>


### PR DESCRIPTION
This harvester has been failing (see #182 and https://github.com/aodn/content/issues/80) because it's been trying to delete data for files that have been removed from the filesystem, but the db connection parameters were incorrectly set for the component that does this. It was trying to "use existing connection", but there wasn't one in that subjob.

This should fix it. I don't have the PO VM set up to test this, so whoever reviews this, please do a test run, delete some files, then test run it again to make sure it works. Thanks!