### PR TITLE
Remove unnecessary netcdfAll-4.2 import

### DIFF
--- a/workspace/AATAMS_ACOUSTIC_REPORTING/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AATAMS_ACOUSTIC_REPORTING/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_YCkCMPPWEea9kMxVEVnhiw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_YCkCMPPWEea9kMxVEVnhiw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AATAMS_SATTAG_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AATAMS_SATTAG_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_G5U1QIoQEeOSmZkgcMlh-A" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_G5U1QIoQEeOSmZkgcMlh-A">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AATAMS_SATTAG_NRT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AATAMS_SATTAG_NRT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_pNmakAhaEeOMauTmlz9RDg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_pNmakAhaEeOMauTmlz9RDg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_CURRENTS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_CURRENTS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_9r7HALriEeOyTf3lKzr0aQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_9r7HALriEeOyTf3lKzr0aQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_SOFS_SURFACE_FLUXES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_SOFS_SURFACE_FLUXES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_mcZcQEzMEeOBHf4HoZ3aaA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_mcZcQEzMEeOBHf4HoZ3aaA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_SOFS_SURFACE_PROPERTIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_SOFS_SURFACE_PROPERTIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_mcZcQEzMEeOBHf4HoZ3aaA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_mcZcQEzMEeOBHf4HoZ3aaA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_SOTS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_SOTS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_0AyYEC2ZEeS5m-ktAuTBXA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_0AyYEC2ZEeS5m-ktAuTBXA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_du0pwJqMEeO0Zev2_0Tm2Q" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_du0pwJqMEeO0Zev2_0Tm2Q">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_DM/ANFOG_DM-master/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_DM/ANFOG_DM-master/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/CreateWMS_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/CreateWMS_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/DataHarvest_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/DataHarvest_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/DeleteMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/DeleteMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/HarvestFileSystemMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/HarvestFileSystemMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/HarvestMetadataFileSystem_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/HarvestMetadataFileSystem_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/mainANFOG_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/mainANFOG_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_ACIDIFICATION_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_ACIDIFICATION_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_82AZENmWEeO8bb6halmGyQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_82AZENmWEeO8bb6halmGyQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_ACIDIFICATION_NRT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_ACIDIFICATION_NRT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_AMYzwIPcEeOq5bSluO1LHw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_AMYzwIPcEeOq5bSluO1LHw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_ADCP_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_ADCP_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_DNm60EzuEeOy9bs6KyqfgQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_DNm60EzuEeOy9bs6KyqfgQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_BURST_AVG_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_BURST_AVG_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_KXuMgEtLEeOc9cU39okcgg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_KXuMgEtLEeOc9cU39okcgg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_METADATA/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_METADATA/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_lwaUkMYSEeW8Vc9VBxRlsA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_lwaUkMYSEeW8Vc9VBxRlsA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_BGC/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_BGC/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_AVA8IOYEEeOYT4GpKsVItw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_AVA8IOYEEeOYT4GpKsVItw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_CTD_PROFILES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_CTD_PROFILES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_Udy1ACf_EeS-YZ9BEyjySQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_Udy1ACf_EeS-YZ9BEyjySQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_DAR_YON_TS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_DAR_YON_TS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_zB-WQGhjEeO4b5nKTTNtKg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_zB-WQGhjEeO4b5nKTTNtKg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_LONG_TS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_LONG_TS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_TvQVMDKPEeaTqO4a6Y4_hw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_TvQVMDKPEeaTqO4a6Y4_hw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_slx3MFCvEeOCRO7vwjey3g" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_slx3MFCvEeOCRO7vwjey3g">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_RT_METEO_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_RT_METEO_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_l_KoEFI6EeOJ8IwO0ZXIhg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_l_KoEFI6EeOJ8IwO0ZXIhg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_l8QicFGUEeO0_O_xyyikdg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_l8QicFGUEeO0_O_xyyikdg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_TS_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_TS_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_12KLIEajEeOQ2fBQ2VIjkw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_12KLIEajEeOQ2fBQ2VIjkw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_T_REGRIDDED/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_T_REGRIDDED/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_8pWAwKTKEeOG4PQo0GPgwA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_8pWAwKTKEeOG4PQo0GPgwA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_WAVE/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_WAVE/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_XYl_EPObEeSFetwq88Dqgw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_XYl_EPObEeSFetwq88Dqgw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_AIMS_CTD/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_AIMS_CTD/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_Jhvn0OcVEeSx3ucN4qWYvQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_Jhvn0OcVEeSx3ucN4qWYvQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_DSTO/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_DSTO/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_jDbJECwaEeSbdaxQG91UUQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_jDbJECwaEeSbdaxQG91UUQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_IMAS_FLUOROMETRY/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_IMAS_FLUOROMETRY/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_VF6RcPxdEeWe9dMpNDdzfA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_VF6RcPxdEeWe9dMpNDdzfA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_MHL_SST/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_MHL_SST/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_pZxHAEVUEeWAbbGk3bSi9g" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_pZxHAEVUEeWAbbGk3bSi9g">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_NT_SATTAG_OLIVERIDLEY/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_NT_SATTAG_OLIVERIDLEY/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_cxSxINdXEeScwdkvzTaC6Q" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_cxSxINdXEeScwdkvzTaC6Q">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_RAN_CTD/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_RAN_CTD/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_kLS9cLb-EeS4hrlMb3uVDw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_kLS9cLb-EeS4hrlMb3uVDw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_RAN_SST/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_RAN_SST/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_rS-1ALcCEeSPKPw-Ov8jfw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_rS-1ALcCEeSPKPw-Ov8jfw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AUS_CHLA_DB/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AUS_CHLA_DB/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_gEmE0EDLEeemPYoVMEjPuQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_gEmE0EDLEeemPYoVMEjPuQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AUS_PHYTO_DB/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AUS_PHYTO_DB/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_391lgDQeEeWQAvJ3lFQaSA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_391lgDQeEeWQAvJ3lFQaSA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AUV/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AUV/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_XfSF0FI0EeOGlPOrA_pPxA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_XfSF0FI0EeOGlPOrA_pPxA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AUV_VIEWER_TRACKS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AUV_VIEWER_TRACKS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_6vcfgDSLEeS5EceRBigRTQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_6vcfgDSLEeS5EceRBigRTQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/FAIMMS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/FAIMMS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_47eCEFriEeOnnvRwM8xJDQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_47eCEFriEeOnnvRwM8xJDQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/FUTURE_REEF_MAP/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/FUTURE_REEF_MAP/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_YI9-sAtDEeazGuXhB80YeQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_YI9-sAtDEeazGuXhB80YeQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/GSLA_DM00/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/GSLA_DM00/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_DQlCUI1EEeOzEJM5QzWEsw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_DQlCUI1EEeOzEJM5QzWEsw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/GSLA_NRT00/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/GSLA_NRT00/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="__bwY4I4fEeOFU8gekOYcvg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="__bwY4I4fEeOFU8gekOYcvg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/HAWKSBILL_TURTLES_NT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/HAWKSBILL_TURTLES_NT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_Bln14BxeEeSD8KGt0_3Kjg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_Bln14BxeEeSD8KGt0_3Kjg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/NOAA_DRIFTERS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/NOAA_DRIFTERS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_P4fCoJ3aEeOtY84-JKwZVQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_P4fCoJ3aEeOtY84-JKwZVQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_ASF_FMT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_ASF_FMT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_OKJSgEEJEeOfvKTm8n14TA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_OKJSgEEJEeOfvKTm8n14TA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_ASF_MT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_ASF_MT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_A_XVYD9rEeOV0rJ0eTNaHw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_A_XVYD9rEeOV0rJ0eTNaHw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_AUSCPR/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_AUSCPR/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_0lisgNr7EeOJ7fDtTdVpJg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_0lisgNr7EeOJ7fDtTdVpJg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_BA/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_BA/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_uQ1JMGX3EeOlJbpHmfPpWQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_uQ1JMGX3EeOlJbpHmfPpWQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_CO2/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_CO2/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_10Vw8D0FEeO87owOoGi4rg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_10Vw8D0FEeO87owOoGi4rg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_CO2_RT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_CO2_RT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_Fft0UJa0EeepL4akcRPIDA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_Fft0UJa0EeepL4akcRPIDA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_SST/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_SST/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_F5A6EDw4EeONDJRZoem8XQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_F5A6EDw4EeONDJRZoem8XQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_TMV/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_TMV/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_ahBDkDxeEeONarTo8EYC7A" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_ahBDkDxeEeONarTo8EYC7A">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_TMV_NRT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_TMV_NRT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_OPzgoIPbEeOFq_P5SMOFrg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_OPzgoIPbEeOFq_P5SMOFrg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_TRV/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_TRV/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_z0fEYEsvEeOpS4EfPHUwwQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_z0fEYEsvEeOpS4EfPHUwwQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_XBT_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_XBT_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_H6eq0EZlEeOfrbssYApjDg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_H6eq0EZlEeOfrbssYApjDg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_ALTIMETRY/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_ALTIMETRY/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_gDSHEJqJEeOUHqqXq3JURQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_gDSHEJqJEeOUHqqXq3JURQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_LJCO_AERONET_TS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_LJCO_AERONET_TS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_dOSGMEIJEeSpJrWF0Q1dog" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_dOSGMEIJEeSpJrWF0Q1dog">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_OC_BODBAW/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_OC_BODBAW/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_OvB3sKpFEeORbauK4C3twA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_OvB3sKpFEeORbauK4C3twA">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_OC_SOOP_RAD/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_OC_SOOP_RAD/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_TWloQIlBEeO1tNDjVKR3Dw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_TWloQIlBEeO1tNDjVKR3Dw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_SST/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_SST/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_WJm0QJ8BEeWYE-06dg8yxg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_WJm0QJ8BEeWYE-06dg8yxg">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/WODB/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/WODB/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_bHACEMEoEeS2d_IRGd5c6Q" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_bHACEMEoEeS2d_IRGd5c6Q">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_y0KMkDp_EeKYTu4DLH4cKg" mESSAGE="" mODULE="netcdfAll-4.2.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="/par2/git-repos/talend_components/iNetCDFInput/netcdfAll-4.2.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>


### PR DESCRIPTION
None of these harvesters need this import statement - its included by iNetCDFInput which can have its version changed separately.  

Using routine library imports is problematic as they require harvesters using them to be updated on a version change.   I think it would be better to add a component which which can be updated independently.  Can add to iIncludeSdiComponents if its ever required.