### PR TITLE
Set TLS 1.2 for default on CSIRO endpoint harvesters

### DIFF
--- a/workspace/ANMN_NRS_BGC/process/ANMN_NRS_BGC/ANMN_NRS_BGC_harvester_0.1.item
+++ b/workspace/ANMN_NRS_BGC/process/ANMN_NRS_BGC/ANMN_NRS_BGC_harvester_0.1.item
@@ -63,7 +63,7 @@
     <contextParameter comment="" name="WfsTimeout" prompt="WfsTimeout?" promptNeeded="false" repositoryContextId="_keR-0ArvEeSHSpYlVevlXQ" type="id_String" value="60000"/>
   </context>
   <parameters>
-    <elementParameter field="TEXT" name="JOB_RUN_VM_ARGUMENTS" value=" -Xms256M -Xmx1024M"/>
+    <elementParameter field="TEXT" name="JOB_RUN_VM_ARGUMENTS" value=" -Xms256M -Xmx1024M -Djdk.tls.client.protocol=TLSv1.2"/>
     <elementParameter field="CHECK" name="JOB_RUN_VM_ARGUMENTS_OPTION" value="false"/>
     <elementParameter field="TEXT" name="SCREEN_OFFSET_X" value="256"/>
     <elementParameter field="TEXT" name="SCREEN_OFFSET_Y" value="224"/>

--- a/workspace/SOOP_AUSCPR/process/SOOP_AUSCPR/SOOP_AUSCPR_harvester_0.1.item
+++ b/workspace/SOOP_AUSCPR/process/SOOP_AUSCPR/SOOP_AUSCPR_harvester_0.1.item
@@ -109,7 +109,7 @@
     <contextParameter comment="" name="WfsTimeout" prompt="WfsTimeout?" promptNeeded="false" repositoryContextId="_DK4xgBbiEeSUt7QBdAE9mA" type="id_String" value="60000"/>
   </context>
   <parameters>
-    <elementParameter field="TEXT" name="JOB_RUN_VM_ARGUMENTS" value=" -Xms256M -Xmx1024M"/>
+    <elementParameter field="TEXT" name="JOB_RUN_VM_ARGUMENTS" value=" -Xms256M -Xmx1024M -Djdk.tls.client.protocol=TLSv1.2"/>
     <elementParameter field="CHECK" name="JOB_RUN_VM_ARGUMENTS_OPTION" value="false"/>
     <elementParameter field="TEXT" name="SCREEN_OFFSET_X" value="0"/>
     <elementParameter field="TEXT" name="SCREEN_OFFSET_Y" value="0"/>


### PR DESCRIPTION
Part of fix for https://github.com/aodn/content/issues/356