### PR TITLE
Fixes incorrect timestamp calculation reported in aodn/content/416

### DIFF
--- a/workspace/AATAMS_ACOUSTIC_REPORTING/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AATAMS_ACOUSTIC_REPORTING/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AATAMS_ACOUSTIC_REPORTING/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AATAMS_ACOUSTIC_REPORTING/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_YCkCMPPWEea9kMxVEVnhiw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_YCkCMPPWEea9kMxVEVnhiw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AATAMS_SATTAG_DM/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AATAMS_SATTAG_DM/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AATAMS_SATTAG_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AATAMS_SATTAG_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_G5U1QIoQEeOSmZkgcMlh-A" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_G5U1QIoQEeOSmZkgcMlh-A">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AATAMS_SATTAG_NRT/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AATAMS_SATTAG_NRT/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AATAMS_SATTAG_NRT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AATAMS_SATTAG_NRT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_pNmakAhaEeOMauTmlz9RDg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_pNmakAhaEeOMauTmlz9RDg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AATAMS_SATTAG_QC_CTD/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AATAMS_SATTAG_QC_CTD/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AATAMS_SATTAG_QC_CTD/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AATAMS_SATTAG_QC_CTD/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_ToseoJ_GEeankdDmXiqyyA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_ToseoJ_GEeankdDmXiqyyA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_CURRENTS/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ABOS_CURRENTS/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ABOS_CURRENTS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_CURRENTS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_9r7HALriEeOyTf3lKzr0aQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_9r7HALriEeOyTf3lKzr0aQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_SOFS_SURFACE_FLUXES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ABOS_SOFS_SURFACE_FLUXES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ABOS_SOFS_SURFACE_FLUXES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_SOFS_SURFACE_FLUXES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_mcZcQEzMEeOBHf4HoZ3aaA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_mcZcQEzMEeOBHf4HoZ3aaA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_SOFS_SURFACE_PROPERTIES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ABOS_SOFS_SURFACE_PROPERTIES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ABOS_SOFS_SURFACE_PROPERTIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_SOFS_SURFACE_PROPERTIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_mcZcQEzMEeOBHf4HoZ3aaA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_mcZcQEzMEeOBHf4HoZ3aaA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ABOS_TS_SINGLE_INST_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_du0pwJqMEeO0Zev2_0Tm2Q" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_du0pwJqMEeO0Zev2_0Tm2Q">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_DM/ANFOG_DM-master/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_DM/ANFOG_DM-master/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_DM/ANFOG_DM-master/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_DM/ANFOG_DM-master/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_DM/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_DM/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/CreateWMS_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_RT/ANFOG_RT/CreateWMS_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_RT/ANFOG_RT/CreateWMS_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/CreateWMS_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/CreateWMS_RT/src/routines/NetCDFUtils.java
+++ b/workspace/ANFOG_RT/ANFOG_RT/CreateWMS_RT/src/routines/NetCDFUtils.java
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_RT/ANFOG_RT/DataHarvest_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_RT/ANFOG_RT/DataHarvest_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_RT/ANFOG_RT/DataHarvest_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/DataHarvest_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/DeleteMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_RT/ANFOG_RT/DeleteMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_RT/ANFOG_RT/DeleteMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/DeleteMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/HarvestFileSystemMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_RT/ANFOG_RT/HarvestFileSystemMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_RT/ANFOG_RT/HarvestFileSystemMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/HarvestFileSystemMetadata_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/HarvestMetadataFileSystem_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_RT/ANFOG_RT/HarvestMetadataFileSystem_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_RT/ANFOG_RT/HarvestMetadataFileSystem_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/HarvestMetadataFileSystem_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/ANFOG_RT/mainANFOG_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_RT/ANFOG_RT/mainANFOG_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_RT/ANFOG_RT/mainANFOG_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/ANFOG_RT/mainANFOG_RT/items/anfog_dm/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_fTErUHjNEeOHDNu5W08gUg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_fTErUHjNEeOHDNu5W08gUg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANFOG_RT/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANFOG_RT/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANFOG_RT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANFOG_RT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_IR-nsH2CEeOH5YTTykZyPA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_IR-nsH2CEeOH5YTTykZyPA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_ACIDIFICATION_DM/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_ACIDIFICATION_DM/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_ACIDIFICATION_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_ACIDIFICATION_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_82AZENmWEeO8bb6halmGyQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_82AZENmWEeO8bb6halmGyQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_ACIDIFICATION_NRT/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_ACIDIFICATION_NRT/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_ACIDIFICATION_NRT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_ACIDIFICATION_NRT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_AMYzwIPcEeOq5bSluO1LHw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_AMYzwIPcEeOq5bSluO1LHw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_ADCP_TIMESERIES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_ADCP_TIMESERIES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_ADCP_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_ADCP_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_DNm60EzuEeOy9bs6KyqfgQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_DNm60EzuEeOy9bs6KyqfgQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_BURST_AVG_TIMESERIES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_BURST_AVG_TIMESERIES/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_BURST_AVG_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_BURST_AVG_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_KXuMgEtLEeOc9cU39okcgg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_KXuMgEtLEeOc9cU39okcgg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_METADATA/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_METADATA/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_METADATA/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_METADATA/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_lwaUkMYSEeW8Vc9VBxRlsA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_lwaUkMYSEeW8Vc9VBxRlsA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_MHLWAVE/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_MHLWAVE/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_MHLWAVE/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_MHLWAVE/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_DD6XENAmEeOojYnxOrOXhw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_DD6XENAmEeOojYnxOrOXhw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_BGC/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_NRS_BGC/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_NRS_BGC/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_BGC/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_AVA8IOYEEeOYT4GpKsVItw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_AVA8IOYEEeOYT4GpKsVItw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_CTD_PROFILES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_NRS_CTD_PROFILES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_NRS_CTD_PROFILES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_CTD_PROFILES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_Udy1ACf_EeS-YZ9BEyjySQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_Udy1ACf_EeS-YZ9BEyjySQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_DAR_YON_TS/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_NRS_DAR_YON_TS/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_NRS_DAR_YON_TS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_DAR_YON_TS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_zB-WQGhjEeO4b5nKTTNtKg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_zB-WQGhjEeO4b5nKTTNtKg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_LONG_TS/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_NRS_LONG_TS/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_NRS_LONG_TS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_LONG_TS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_TvQVMDKPEeaTqO4a6Y4_hw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_TvQVMDKPEeaTqO4a6Y4_hw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_RT_BIOGEOCHEM_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_slx3MFCvEeOCRO7vwjey3g" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_slx3MFCvEeOCRO7vwjey3g">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_RT_METEO_TIMESERIES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_NRS_RT_METEO_TIMESERIES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_NRS_RT_METEO_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_RT_METEO_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_l_KoEFI6EeOJ8IwO0ZXIhg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_l_KoEFI6EeOJ8IwO0ZXIhg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_NRS_RT_WAVE_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_l8QicFGUEeO0_O_xyyikdg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_l8QicFGUEeO0_O_xyyikdg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_TS_TIMESERIES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_TS_TIMESERIES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_TS_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_TS_TIMESERIES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_12KLIEajEeOQ2fBQ2VIjkw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_12KLIEajEeOQ2fBQ2VIjkw">
     <content href="NetCDFUtils_0.1.item#/"/>
-    <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
   </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_T_REGRIDDED/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_T_REGRIDDED/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_T_REGRIDDED/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_T_REGRIDDED/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_8pWAwKTKEeOG4PQo0GPgwA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_8pWAwKTKEeOG4PQo0GPgwA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ANMN_WAVE/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ANMN_WAVE/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ANMN_WAVE/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ANMN_WAVE/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_XYl_EPObEeSFetwq88Dqgw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_XYl_EPObEeSFetwq88Dqgw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_AIMS_CTD/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_AIMS_CTD/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_AIMS_CTD/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_AIMS_CTD/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_Jhvn0OcVEeSx3ucN4qWYvQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_Jhvn0OcVEeSx3ucN4qWYvQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_BOM_SEA_LEVEL/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_BOM_SEA_LEVEL/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_BOM_SEA_LEVEL/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_BOM_SEA_LEVEL/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_JUia4LSHEeidp9lJouHjGQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_JUia4LSHEeidp9lJouHjGQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_DSTO/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_DSTO/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_DSTO/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_DSTO/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_jDbJECwaEeSbdaxQG91UUQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_jDbJECwaEeSbdaxQG91UUQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_IMAS_FLUOROMETRY/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_IMAS_FLUOROMETRY/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_IMAS_FLUOROMETRY/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_IMAS_FLUOROMETRY/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_VF6RcPxdEeWe9dMpNDdzfA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_VF6RcPxdEeWe9dMpNDdzfA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_MHL_SST/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_MHL_SST/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_MHL_SST/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_MHL_SST/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_pZxHAEVUEeWAbbGk3bSi9g" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_pZxHAEVUEeWAbbGk3bSi9g">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_NT_SATTAG_OLIVERIDLEY/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_NT_SATTAG_OLIVERIDLEY/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_NT_SATTAG_OLIVERIDLEY/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_NT_SATTAG_OLIVERIDLEY/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_cxSxINdXEeScwdkvzTaC6Q" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_cxSxINdXEeScwdkvzTaC6Q">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_RAN_SST/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_RAN_SST/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_RAN_SST/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_RAN_SST/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_rS-1ALcCEeSPKPw-Ov8jfw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_rS-1ALcCEeSPKPw-Ov8jfw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_WAVE_DM/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_WAVE_DM/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_WAVE_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_WAVE_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_rxupYMYCEeiew5BeScl3UA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_rxupYMYCEeiew5BeScl3UA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AODN_WAVE_NRT/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AODN_WAVE_NRT/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AODN_WAVE_NRT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AODN_WAVE_NRT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_JWh9gJnYEeeRT-WmcD4skA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_JWh9gJnYEeeRT-WmcD4skA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/ARGO/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/ARGO/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/ARGO/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/ARGO/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_RK7IIAM2EeS7uLOnmFTdhQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_RK7IIAM2EeS7uLOnmFTdhQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AUS_CHLA_DB/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AUS_CHLA_DB/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AUS_PHYTO_DB/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AUS_PHYTO_DB/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AUV/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AUV/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AUV/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AUV/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_XfSF0FI0EeOGlPOrA_pPxA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_XfSF0FI0EeOGlPOrA_pPxA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/AUV_VIEWER_TRACKS/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/AUV_VIEWER_TRACKS/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/AUV_VIEWER_TRACKS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/AUV_VIEWER_TRACKS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_6vcfgDSLEeS5EceRBigRTQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_6vcfgDSLEeS5EceRBigRTQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/FAIMMS/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/FAIMMS/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/FAIMMS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/FAIMMS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_47eCEFriEeOnnvRwM8xJDQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_47eCEFriEeOnnvRwM8xJDQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/FUTURE_REEF_MAP/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/FUTURE_REEF_MAP/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/FUTURE_REEF_MAP/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/FUTURE_REEF_MAP/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_YI9-sAtDEeazGuXhB80YeQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_YI9-sAtDEeazGuXhB80YeQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/GSLA_DM00/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/GSLA_DM00/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/GSLA_DM00/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/GSLA_DM00/code/routines/NetCDFUtils_0.1.properties
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmlns:xmi="http://www.omg.org/XMI" xmlns:TalendProperties="http://www.talend.org/properties" xmi:version="2.0">
-  <TalendProperties:Property xmi:id="_IMhOEDp8EeKYTu4DLH4cKg" id="_IMfY4Dp8EeKYTu4DLH4cKg" label="NetCDFUtils" creationDate="2012-11-30T11:25:57.489+1100" modificationDate="2013-10-15T11:02:22.890+1100" version="0.1" statusCode="" item="_IMhOEjp8EeKYTu4DLH4cKg" displayName="NetCDFUtils">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:TalendProperties="http://www.talend.org/properties">
+  <TalendProperties:Property xmi:id="_IMhOEDp8EeKYTu4DLH4cKg" id="_IMfY4Dp8EeKYTu4DLH4cKg" label="NetCDFUtils" creationDate="2012-11-30T11:25:57.489+1100" modificationDate="2019-06-27T14:41:38.184+1000" version="0.1" statusCode="" item="_IMhOEjp8EeKYTu4DLH4cKg" displayName="NetCDFUtils">
     <author href="../../talend.project#__26ZEoyZEeOPI483lK-ylA"/>
   </TalendProperties:Property>
   <TalendProperties:ItemState xmi:id="_DQlCUI1EEeOzEJM5QzWEsw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_DQlCUI1EEeOzEJM5QzWEsw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/GSLA_DM00/code/routines/system/GeometryOperation_0.1.item
+++ b/workspace/GSLA_DM00/code/routines/system/GeometryOperation_0.1.item
@@ -1,7 +1,7 @@
 // ============================================================================
 //
 // Copyright (C) 2007-2008 Camptocamp - www.camptocamp.com
-//				 2006-2010 Talend Inc. - www.talend.com
+//                 2006-2010 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -38,7 +38,7 @@ public class GeometryOperation {
      * 
      */
     public static Double GETLENGTH(Geometry geom) {
-	return geom.getLength();
+    return geom.getLength();
     }
 
     /**
@@ -54,7 +54,7 @@ public class GeometryOperation {
      * 
      */
     public static Double GETAREA(Geometry geom) {
-	return geom.getArea();
+    return geom.getArea();
     }
 
     /**
@@ -70,7 +70,7 @@ public class GeometryOperation {
      * 
      */
     public static int GETNUMPOINTS(Geometry geom) {
-	return geom.getNumPoints();
+    return geom.getNumPoints();
     }
 
     /**
@@ -87,7 +87,7 @@ public class GeometryOperation {
      * 
      */
     public static int GETNUMGEOMETRIES(Geometry geom) {
-	return geom.getNumGeometries();
+    return geom.getNumGeometries();
     }
 
     /**
@@ -103,7 +103,7 @@ public class GeometryOperation {
      * 
      */
     public static String GETGEOMETRYTYPE(Geometry geom) {
-	return geom.getGeometryType();
+    return geom.getGeometryType();
     }
 
     /**
@@ -119,7 +119,49 @@ public class GeometryOperation {
      * 
      */
     public static int GETSRID(Geometry geom) {
-	return geom.getSRID();
+    return geom.getSRID();
+    }
+    
+    /**
+     * PROJ( ) Reproject specified geometry from on CRS to another.
+     * Return null if error.
+     * Does not support Grid transformation (use sProj component).
+     * 
+     * {talendTypes} geometry | Geometry
+     * 
+     * {Category} GeometryOperation
+     * 
+     * {param} Geometry(null)
+     * 
+     * {param} String(null)
+     * 
+     * {param} String(null)
+     * 
+     * {param} boolean(null)
+     * 
+     * {example} PROJ(row.the_geom, "4326", "2154", false)
+     * 
+     */
+    public static Geometry PROJ(Geometry geom, String fromEPSG, String toEPSG, boolean lenient) {
+
+        org.opengis.referencing.crs.CoordinateReferenceSystem sourceCRS = null;
+        org.opengis.referencing.crs.CoordinateReferenceSystem targetCRS = null;
+        org.opengis.referencing.operation.MathTransform transform = null;
+        try {
+            sourceCRS = org.geotools.referencing.CRS.decode(fromEPSG, true);
+            targetCRS = org.geotools.referencing.CRS.decode(toEPSG, true);
+            transform = org.geotools.referencing.CRS.findMathTransform(
+                    sourceCRS, targetCRS, false);
+            org.talend.sdi.geometry.Geometry geomProj = new org.talend.sdi.geometry.Geometry(
+                    org.geotools.geometry.jts.JTS.transform(
+                            geom._getInternalGeometry(), transform));
+
+            geomProj.setCRS(targetCRS);
+            return geomProj;
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            return null;
+        }
     }
 
     /**
@@ -137,7 +179,7 @@ public class GeometryOperation {
      * 
      */
     public static boolean EQUALS(Geometry geom1, Geometry geom2) {
-	return geom1.equals(geom2);
+    return geom1.equals(geom2);
     }
 
     /**
@@ -155,7 +197,7 @@ public class GeometryOperation {
      * 
      */
     public static double DISTANCE(Geometry geom1, Geometry geom2) {
-	return geom1.distance(geom2);
+    return geom1.distance(geom2);
     }
 
     /**
@@ -171,7 +213,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry GETCENTROID(Geometry geom) {
-	return geom.getCentroid();
+    return geom.getCentroid();
     }
 
     /**
@@ -188,7 +230,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry GETINTERIORPOINT(Geometry geom) {
-	return geom.getInteriorPoint();
+    return geom.getInteriorPoint();
     }
 
     /**
@@ -204,7 +246,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry GETENVELOPE(Geometry geom) {
-	return geom.getEnvelope();
+    return geom.getEnvelope();
     }
 
     /**
@@ -220,7 +262,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry GETBOUNDARY(Geometry geom) {
-	return geom.getBoundary();
+    return geom.getBoundary();
     }
 
     /**
@@ -237,7 +279,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry GETCONVEXHULL(Geometry geom) {
-	return geom.convexHull();
+    return geom.convexHull();
     }
 
     /**
@@ -255,7 +297,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry GETGEOMETRYN(Geometry geom, int n) {
-	return geom.getGeometryN(n);
+    return geom.getGeometryN(n);
     }
 
     /**
@@ -278,27 +320,27 @@ public class GeometryOperation {
      * 
      */
     public static double GETCOORDINATE(Geometry geom, int n, String xyz) {
-	Coordinate[] coords = geom.getCoordinates();
+    Coordinate[] coords = geom.getCoordinates();
 
-	// return last one
-	if (n == -1)
-	    if (xyz.equalsIgnoreCase("X"))
-		return coords[coords.length - 1].x;
-	    else if (xyz.equalsIgnoreCase("Y"))
-		return coords[coords.length - 1].y;
-	    else
-		return coords[coords.length - 1].z;
+    // return last one
+    if (n == -1)
+        if (xyz.equalsIgnoreCase("X"))
+        return coords[coords.length - 1].x;
+        else if (xyz.equalsIgnoreCase("Y"))
+        return coords[coords.length - 1].y;
+        else
+        return coords[coords.length - 1].z;
 
-	// Not so many points
-	if (n >= coords.length)
-	    return -1;
+    // Not so many points
+    if (n >= coords.length)
+        return -1;
 
-	if (xyz.equalsIgnoreCase("X"))
-	    return coords[n].x;
-	else if (xyz.equalsIgnoreCase("Y"))
-	    return coords[n].y;
-	else
-	    return coords[n].z;
+    if (xyz.equalsIgnoreCase("X"))
+        return coords[n].x;
+    else if (xyz.equalsIgnoreCase("Y"))
+        return coords[n].y;
+    else
+        return coords[n].z;
     }
 
     /**
@@ -319,7 +361,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry SIMPLIFY(Geometry geom, String type, double tolerance) {
-	return geom.simplify(type, tolerance);
+    return geom.simplify(type, tolerance);
     }
 
     /**
@@ -342,19 +384,19 @@ public class GeometryOperation {
      * 
      */
     public static Geometry GETBUFFER(Geometry geom, double d, int quantization,
-	    String endCapStyle) {
-	int ecs = com.vividsolutions.jts.operation.buffer.BufferOp.CAP_BUTT;
+        String endCapStyle) {
+    int ecs = com.vividsolutions.jts.operation.buffer.BufferOp.CAP_BUTT;
 
-	if (endCapStyle != null) {
-	    if (endCapStyle.equals("ROUND"))
-		ecs = com.vividsolutions.jts.operation.buffer.BufferOp.CAP_ROUND;
-	    else if (endCapStyle.equals("SQUARE"))
-		ecs = com.vividsolutions.jts.operation.buffer.BufferOp.CAP_SQUARE;
-	    else if (endCapStyle.equals("FLAT"))
-		ecs = com.vividsolutions.jts.operation.buffer.BufferOp.CAP_FLAT;
-	}
+    if (endCapStyle != null) {
+        if (endCapStyle.equals("ROUND"))
+        ecs = com.vividsolutions.jts.operation.buffer.BufferOp.CAP_ROUND;
+        else if (endCapStyle.equals("SQUARE"))
+        ecs = com.vividsolutions.jts.operation.buffer.BufferOp.CAP_SQUARE;
+        else if (endCapStyle.equals("FLAT"))
+        ecs = com.vividsolutions.jts.operation.buffer.BufferOp.CAP_FLAT;
+    }
 
-	return geom.buffer(d, quantization, ecs);
+    return geom.buffer(d, quantization, ecs);
     }
 
     /**
@@ -372,7 +414,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry INTERSECTION(Geometry geom, Geometry geom1) {
-	return geom.intersection(geom1);
+    return geom.intersection(geom1);
     }
 
     /**
@@ -390,7 +432,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry UNION(Geometry geom, Geometry geom1) {
-	return geom.union(geom1);
+    return geom.union(geom1);
     }
 
     /**
@@ -409,7 +451,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry SYMDIFFERENCE(Geometry geom, Geometry geom1) {
-	return geom.symDifference(geom1);
+    return geom.symDifference(geom1);
     }
 
     /**
@@ -427,7 +469,7 @@ public class GeometryOperation {
      * 
      */
     public static Geometry DIFFERENCE(Geometry geom, Geometry geom1) {
-	return geom.difference(geom1);
+    return geom.difference(geom1);
     }
 
     /**
@@ -443,7 +485,7 @@ public class GeometryOperation {
      * 
      */
     public static String ISVALID(Geometry geom) {
-	return geom.isValid();
+    return geom.isValid();
     }
 
     /**
@@ -459,7 +501,7 @@ public class GeometryOperation {
      * 
      */
     public static String TOWKT(Geometry geom) {
-	return geom.toString();
+    return geom.toString();
     }
 
 }

--- a/workspace/GSLA_DM00/code/routines/system/GeometryOperation_0.1.properties
+++ b/workspace/GSLA_DM00/code/routines/system/GeometryOperation_0.1.properties
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:TalendProperties="http://www.talend.org/properties">
-  <TalendProperties:Property xmi:id="_BFoO8YyaEeOPI483lK-ylA" id="_BFoO8IyaEeOPI483lK-ylA" label="GeometryOperation" creationDate="2014-02-03T18:11:27.711+1100" modificationDate="2014-02-03T18:11:27.711+1100" version="0.1" item="_BFoO84yaEeOPI483lK-ylA">
+  <TalendProperties:Property xmi:id="_BFoO8YyaEeOPI483lK-ylA" id="_BFoO8IyaEeOPI483lK-ylA" label="GeometryOperation" creationDate="2014-02-03T18:11:27.711+1100" modificationDate="2019-06-27T14:40:27.839+1000" version="0.1" item="_BFoO84yaEeOPI483lK-ylA">
     <author href="../../../talend.project#__26ZEoyZEeOPI483lK-ylA"/>
   </TalendProperties:Property>
   <TalendProperties:ItemState xmi:id="_BFoO8oyaEeOPI483lK-ylA" path="system"/>

--- a/workspace/GSLA_NRT00/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/GSLA_NRT00/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/GSLA_NRT00/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/GSLA_NRT00/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="__bwY4I4fEeOFU8gekOYcvg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="__bwY4I4fEeOFU8gekOYcvg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/HAWKSBILL_TURTLES_NT/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/HAWKSBILL_TURTLES_NT/code/routines/NetCDFUtils_0.1.item
@@ -1,83 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
+     * date 1/1/1950 00:00:00 #
+     */
+    public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
+        if (days == null || days.isNaN()) return null;
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
+        }
+
+        return new Date(resultMillis);
+    }
+
+    /**
+     * addDays: add days including fractional component to reference date.
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} date(referenceDate) input: the reference date.
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
-		if (days == null || days.isNaN()) return null;
-		
-		DateUnit result;
-		
-		try {
-			SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			result = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-		} catch (Exception e) {
-            throw new RuntimeException(e);
-		}
-		
-		return result.getDate();
+        return addDays(referenceDate, days, false);
     }
-	
-	
+
+
+    /**
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
+     * {talendTypes} Date
+     *
+     * {Category} NetCDF
+     *
+     * {param} string(referenceDate) input: the reference date.
+     *
+     * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
+     *
+     * {param} double(addValue) days : days since the reference date including fractional component
+     *
+     * {param} boolean(nearestSecond) nearestSecond : round to nearest second
+     *
+     * {example}
+     *
+     * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
+     */
+    public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
-    	if (stringDate == null || stringDate.equals("")) return null;
-		
-		return addDays(TalendDate.parseDate(format, stringDate), days);
+        return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/HAWKSBILL_TURTLES_NT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/HAWKSBILL_TURTLES_NT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_Bln14BxeEeSD8KGt0_3Kjg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_Bln14BxeEeSD8KGt0_3Kjg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/NOAA_DRIFTERS/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/NOAA_DRIFTERS/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/NOAA_DRIFTERS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/NOAA_DRIFTERS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_P4fCoJ3aEeOtY84-JKwZVQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_P4fCoJ3aEeOtY84-JKwZVQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_ASF_FMT/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_ASF_FMT/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_ASF_FMT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_ASF_FMT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_OKJSgEEJEeOfvKTm8n14TA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_OKJSgEEJEeOfvKTm8n14TA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_ASF_MT/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_ASF_MT/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_ASF_MT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_ASF_MT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_A_XVYD9rEeOV0rJ0eTNaHw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_A_XVYD9rEeOV0rJ0eTNaHw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_AUSCPR/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_AUSCPR/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_AUSCPR/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_AUSCPR/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_0lisgNr7EeOJ7fDtTdVpJg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_0lisgNr7EeOJ7fDtTdVpJg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_BA/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_BA/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_BA/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_BA/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_uQ1JMGX3EeOlJbpHmfPpWQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_uQ1JMGX3EeOlJbpHmfPpWQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_CO2/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_CO2/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_CO2/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_CO2/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_10Vw8D0FEeO87owOoGi4rg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_10Vw8D0FEeO87owOoGi4rg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_CO2_RT/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_CO2_RT/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_CO2_RT/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_CO2_RT/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_Fft0UJa0EeepL4akcRPIDA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_Fft0UJa0EeepL4akcRPIDA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_SST/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_SST/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_SST/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_SST/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_F5A6EDw4EeONDJRZoem8XQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_F5A6EDw4EeONDJRZoem8XQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_TMV/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_TMV/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_TMV/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_TMV/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_ahBDkDxeEeONarTo8EYC7A" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_ahBDkDxeEeONarTo8EYC7A">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_TRV/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_TRV/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_TRV/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_TRV/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_z0fEYEsvEeOpS4EfPHUwwQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_z0fEYEsvEeOpS4EfPHUwwQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SOOP_XBT_DM/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SOOP_XBT_DM/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SOOP_XBT_DM/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SOOP_XBT_DM/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_H6eq0EZlEeOfrbssYApjDg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_H6eq0EZlEeOfrbssYApjDg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_ALTIMETRY/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SRS_ALTIMETRY/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SRS_ALTIMETRY/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_ALTIMETRY/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_gDSHEJqJEeOUHqqXq3JURQ" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_gDSHEJqJEeOUHqqXq3JURQ">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_LJCO_AERONET_TS/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SRS_LJCO_AERONET_TS/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SRS_LJCO_AERONET_TS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_LJCO_AERONET_TS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_dOSGMEIJEeSpJrWF0Q1dog" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_dOSGMEIJEeSpJrWF0Q1dog">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_OC_BODBAW/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SRS_OC_BODBAW/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SRS_OC_BODBAW/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_OC_BODBAW/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_OvB3sKpFEeORbauK4C3twA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_OvB3sKpFEeORbauK4C3twA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_OC_LJCO_WWS/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SRS_OC_LJCO_WWS/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SRS_OC_LJCO_WWS/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_OC_LJCO_WWS/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_u5_XkKOJEeWcR-kh2PkaiA" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_u5_XkKOJEeWcR-kh2PkaiA">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_OC_SOOP_RAD/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SRS_OC_SOOP_RAD/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SRS_OC_SOOP_RAD/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_OC_SOOP_RAD/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_TWloQIlBEeO1tNDjVKR3Dw" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_TWloQIlBEeO1tNDjVKR3Dw">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_SST/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SRS_SST/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SRS_SST/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_SST/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_WJm0QJ8BEeWYE-06dg8yxg" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_WJm0QJ8BEeWYE-06dg8yxg">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/SRS_SURFACE_WAVES/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/SRS_SURFACE_WAVES/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/SRS_SURFACE_WAVES/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/SRS_SURFACE_WAVES/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_CKsVUPgdEeizKKKCuq_Kww" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_CKsVUPgdEeizKKKCuq_Kww">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>

--- a/workspace/WODB/code/routines/NetCDFUtils_0.1.item
+++ b/workspace/WODB/code/routines/NetCDFUtils_0.1.item
@@ -1,141 +1,226 @@
 package routines;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
-import ucar.nc2.units.DateUnit;
+import routines.system.FastDateParser;
 
 /*
  * user specification: the function's comment should contain keys as follows: 1. write about the function's comment.but
  * it must be before the "{talendTypes}" key.
- * 
+ *
  * 2. {talendTypes} 's value must be talend Type, it is required . its value should be one of: String, char | Character,
  * long | Long, int | Integer, boolean | Boolean, byte | Byte, Date, double | Double, float | Float, Object, short |
  * Short
- * 
+ *
  * 3. {Category} define a category for the Function. it is required. its value is user-defined .
- * 
+ *
  * 4. {param} 's format is: {param} <type>[(<default value or closed list values>)] <name>[ : <comment>]
- * 
+ *
  * <type> 's value should be one of: string, int, list, double, object, boolean, long, char, date. <name>'s value is the
  * Function's parameter name. the {param} is optional. so if you the Function without the parameters. the {param} don't
  * added. you can have many parameters for the Function.
- * 
+ *
  * 5. {example} gives a example for the Function. it is optional.
  */
 public class NetCDFUtils {
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days, boolean nearestSecond) {
         if (days == null || days.isNaN()) return null;
-        
-        DateUnit netcdfDate;
-        
-        try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            netcdfDate = new DateUnit(days + " days since " + dateFormatter.format(referenceDate));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+
+        long referenceMillis = referenceDate.getTime();
+        long resultMillis = referenceMillis + Math.round(days * 24.0 * 60.0 * 60.0 * 1000);
+
+        if (nearestSecond) {
+            resultMillis = Math.round(resultMillis/1000.0)*1000;
         }
 
-        Date result = netcdfDate.getDate();
-        
-        if (nearestSecond) {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(result);
-            cal.add( Calendar.MILLISECOND, 500 );
-            cal.set( Calendar.MILLISECOND, 0);
-            result = cal.getTime();
-        }
-        
-        return result;
+        return new Date(resultMillis);
     }
-    
+
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} date(referenceDate) input: the reference date.
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
-     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference 
+     *
+     * {example}
+     *
+     * ->> addDays(referenceDate, new Double("19326.1830555648") returns date 30/11/2002 04:23:36 with reference
      * date 1/1/1950 00:00:00 #
      */
     public static Date addDays(Date referenceDate, Double days) {
         return addDays(referenceDate, days, false);
     }
-    
-	
+
+
     /**
-     * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     * addDays: add days including fractional component to reference date (UTC).
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
+     *
      * {param} boolean(nearestSecond) nearestSecond : round to nearest second
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648", false) returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days, boolean nearestSecond) {
-        if (stringDate == null || stringDate.equals("")) return null;
-        
-        return addDays(TalendDate.parseDate(format, stringDate), days, nearestSecond);
+        try {
+            if (stringDate == null || stringDate.equals("")) return null;
+            DateFormat df = FastDateParser.getInstance(format);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = df.parse(stringDate);
+            return addDays(date, days, nearestSecond);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * addDays: add days including fractional component to reference date.
-     * 
-     * 
+     *
+     *
      * {talendTypes} Date
-     * 
+     *
      * {Category} NetCDF
-     * 
+     *
      * {param} string(referenceDate) input: the reference date.
-     * 
+     *
      * {param} string(format) input: format of the reference date (as per SimpleDateFormat).
-     * 
+     *
      * {param} double(addValue) days : days since the reference date including fractional component
-     * 
-     * {example} 
-     * 
+     *
+     * {example}
+     *
      * ->> addDays("19500101000000", "yyyyMMddHHmmss", new Double("19326.1830555648") returns date 30/11/2002 04:23:36 #
      */
     public static Date addDays(String stringDate, String format, Double days) {
         return addDays(stringDate, format, days, false);
+    }
+
+    /**
+     * testAddDays: test addDays stringDate method
+     */
+
+    public static void testAddDays() {
+
+        // Create utc date parser/formatter for use in tests
+
+        SimpleDateFormat utcDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        utcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        // 'Manually' test some Australian daylight time affected/unaffected dates
+
+        Object[][] testCases1 = {
+            {"19500101000000","yyyyMMddHHmmss", 19326.1830555648, "2002-11-30 04:23:36"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24926.625011999975, "2018-03-31 15:00:01"},
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss", 24985.53751199995, "2018-05-29 12:54:01"}
+        };
+
+        for (Object[] testCase: testCases1) {
+            String testDate = (String) testCase[0];
+            String testFormat = (String) testCase[1];
+            double daysToAdd = (Double) testCase[2];
+            String expected = (String) testCase[3];
+
+            Date result = addDays(testDate, testFormat, daysToAdd, true);
+            Date expectedDate;
+
+            try {
+                expectedDate = utcDateFormat.parse(expected);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!expectedDate.equals(result)) {
+                String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f'",
+                    expected, utcDateFormat.format(result), testDate, testFormat, daysToAdd);
+                System.err.println(errorString);
+            }
+        }
+
+        // More exhaustive testing using non time zone affected calculations for comparison
+
+        long referenceTime = -631152000000l; // time in milliseconds after January 1, 1970 00:00:00 GMT for reference date
+                                            // 1/1/1950 00:00:00 UTC
+
+        String[][] testCases = {
+            {"01/01/1950 00:00:00","MM/dd/yyyy HH:mm:ss"},
+            {"1950-01-01 00:00:00","yyyy-MM-dd HH:mm:ss"},
+            {"19500101000000", "yyyyMMddHHmmss"}
+        };
+
+        // loop through each test case (reference date/formats used by harvesters)
+        for (String[] testCase: testCases) {
+            String testDate = testCase[0];
+            String testFormat = testCase[1];
+
+            // Loop through every 1/2 hour time increment (from 1/1/1950 to 29/4/2019)
+            for (double daysToAdd=0; daysToAdd < 25202;  daysToAdd+=1.0/24.0/2.0) {
+
+                // loop through possible rounding values
+                for (boolean roundToNearestSecond: new boolean[] {false, true}) {
+                    // test date returned from addDays for test daysToAdd and format rounding to nearest second
+                    // against 1950-01-01 00:00:00 GMT plus daysToAdd rounded to nearest second
+
+                    Date result = NetCDFUtils.addDays(testDate, testFormat, daysToAdd, roundToNearestSecond);
+
+                    // calculate expected result without any date parsing/formatting/time zone processing
+                    long referenceResult = referenceTime + Math.round(daysToAdd * 24.0 * 60 * 60 * 1000);
+
+                    if (roundToNearestSecond) {
+                        referenceResult = Math.round(referenceResult/1000.0) * 1000;
+                    }
+
+                    Date expected = new Date(referenceResult);
+
+                    if (!result.equals(expected)) {
+                        String errorString = String.format("Expected '%s' but got '%s' for '%s', '%s', '%f', '%b'",
+                            utcDateFormat.format(expected), utcDateFormat.format(result), testDate, testFormat,
+                            daysToAdd, roundToNearestSecond);
+                        System.err.println(errorString);
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/workspace/WODB/code/routines/NetCDFUtils_0.1.properties
+++ b/workspace/WODB/code/routines/NetCDFUtils_0.1.properties
@@ -6,6 +6,5 @@
   <TalendProperties:ItemState xmi:id="_bHACEMEoEeS2d_IRGd5c6Q" path=""/>
   <TalendProperties:RoutineItem xmi:id="_IMhOEjp8EeKYTu4DLH4cKg" property="_IMhOEDp8EeKYTu4DLH4cKg" state="_bHACEMEoEeS2d_IRGd5c6Q">
     <content href="NetCDFUtils_0.1.item#/"/>
-      <imports xmi:id="_p_cZMFysEemf8NNMGuRM2g" mESSAGE="" mODULE="netcdfAll-4.6.4.jar" nAME="NetCDFUtils" rEQUIRED="true" urlPath="netcdfAll-4.6.4.jar"/>
-    </TalendProperties:RoutineItem>
+  </TalendProperties:RoutineItem>
 </xmi:XMI>


### PR DESCRIPTION
 for anmn_ts_timeseries harvester

Problem occurred when using Calendar instance to round to nearest second.  There was an associated time zone of AEDT which got converted to AEST when adding 500ms for some reason.

Remove dependency on netcdf library for performing this calculation.

Add unit testing code to routine.