### PR TITLE
Fixes #720 - specifiy field separator for implict context load

### DIFF
--- a/workspace/SRS_OC_SOOP_RAD/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
+++ b/workspace/SRS_OC_SOOP_RAD/process/harvestMetadata_filesystem/HarvestMetadataFromFileSystem_0.1.item
@@ -24,7 +24,7 @@
     <elementParameter field="CHECK" name="IMPLICIT_TCONTEXTLOAD" value="true"/>
     <elementParameter field="RADIO" name="FROM_FILE_FLAG_IMPLICIT_CONTEXT" value="true"/>
     <elementParameter field="FILE" name="IMPLICIT_TCONTEXTLOAD_FILE" value="context.paramFile"/>
-    <elementParameter field="TEXT" name="FIELDSEPARATOR" value="&quot;&quot;"/>
+    <elementParameter field="TEXT" name="FIELDSEPARATOR" value="&quot;=>&quot;"/>
     <elementParameter field="CLOSED_LIST" name="DB_VERSION_IMPLICIT_CONTEXT" value=""/>
     <elementParameter field="CHECK" name="DISABLE_WARNINGS" value="false"/>
     <elementParameter field="CHECK" name="DISABLE_INFO" value="false"/>


### PR DESCRIPTION
Probably doesn't need to use implicit context load option here, but just adding separator to fix TOS7 abort