### PR TITLE
Update Jenkinsfile to deep clone, for commit comparison

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
                 [
                     $class: 'CloneOption',
                     reference: '/var/lib/jenkins/reference_repos/aodn/harvesters.git',
-                    shallow: true,
+                    shallow: false,  // must be a deep clone in order for `git merge-base` to determine where branch was forked from
                     noTags: true,
                     honorRefspec: true
                 ],
@@ -36,7 +36,6 @@ node {
         } else {
             if (scmVars.GIT_PREVIOUS_COMMIT == null) {
                 // if the previous commit cannot be determined, compare this commit to the master branch to detect changes
-                sh(returnStdout: true, script: "git fetch --no-tags --depth 1 origin master")
                 base = sh(returnStdout: true, script: "git merge-base origin/master HEAD").trim()
             } else {
                 base = scmVars.GIT_PREVIOUS_COMMIT


### PR DESCRIPTION
Optimising the SCM in https://github.com/aodn/harvesters/pull/798 to do a shallow clone in fact broke the  `merge-base`. This reverts it to a deep clone, which restores the ability to find the BASE commit for comparson and detecting changes.